### PR TITLE
Add initial IPod integration

### DIFF
--- a/docs/controllers/IPodController.yaml
+++ b/docs/controllers/IPodController.yaml
@@ -1,0 +1,58 @@
+components:
+  responses:
+    ipodSettings200:
+      description: Successful response - IPod settings
+      content:
+        application/json:
+          schema:
+            $ref: '../objects/settings/IPodSettings.yaml#/components/schemas/IPodSettings'
+paths:
+  /api/ipods/settings:
+    get:
+      summary: Get iPod settings
+      operationId: getIPodSettings
+      tags:
+        - IPod
+      responses:
+        200:
+          $ref: '#/components/responses/ipodSettings200'
+    patch:
+      summary: Update iPod settings
+      operationId: updateIPodSettings
+      tags:
+        - IPod
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '../objects/settings/IPodSettings.yaml#/components/schemas/IPodSettings'
+      responses:
+        200:
+          $ref: '#/components/responses/ipodSettings200'
+  /api/ipods/send:
+    post:
+      summary: Send file to iPod
+      operationId: sendToIPod
+      tags:
+        - IPod
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                libraryItemId:
+                  $ref: '../objects/LibraryItem.yaml#/components/schemas/libraryItemId'
+                deviceName:
+                  $ref: '../objects/settings/IPodSettings.yaml#/components/schemas/ipodName'
+      responses:
+        200:
+          description: Successful response
+        400:
+          description: Invalid request
+        403:
+          description: Forbidden
+        404:
+          description: Not found

--- a/docs/objects/settings/IPodSettings.yaml
+++ b/docs/objects/settings/IPodSettings.yaml
@@ -1,0 +1,39 @@
+components:
+  schemas:
+    ipodName:
+      type: string
+      description: The name of the iPod device.
+    IPodDevice:
+      type: object
+      description: A configured iPod sync device.
+      properties:
+        name:
+          $ref: '#/components/schemas/ipodName'
+        ip:
+          type: string
+          description: IP address of the device.
+        availabilityOption:
+          type: string
+          enum: ['adminOrUp', 'userOrUp', 'guestOrUp', 'specificUsers']
+        users:
+          type: array
+          items:
+            type: string
+      required:
+        - name
+        - ip
+        - availabilityOption
+    IPodSettings:
+      type: object
+      description: Settings for configured iPod devices.
+      properties:
+        id:
+          type: string
+          example: ipod-settings
+        ipodDevices:
+          type: array
+          items:
+            $ref: '#/components/schemas/IPodDevice'
+      required:
+        - id
+        - ipodDevices

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -40,6 +40,10 @@
     {
       "name": "Podcasts",
       "description": "Podcast endpoints"
+    },
+    {
+      "name": "IPod",
+      "description": "iPod endpoints"
     }
   ],
   "paths": {
@@ -529,6 +533,83 @@
                   },
                   "deviceName": {
                     "$ref": "#/components/schemas/ereaderName"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/ipods/settings": {
+      "get": {
+        "summary": "Get iPod settings",
+        "operationId": "getIPodSettings",
+        "tags": [
+          "IPod"
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ipodSettings200"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update iPod settings",
+        "operationId": "updateIPodSettings",
+        "tags": [
+          "IPod"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IPodSettings"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ipodSettings200"
+          }
+        }
+      }
+    },
+    "/api/ipods/send": {
+      "post": {
+        "summary": "Send file to iPod",
+        "operationId": "sendToIPod",
+        "tags": [
+          "IPod"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "libraryItemId": {
+                    "$ref": "#/components/schemas/libraryItemId"
+                  },
+                  "deviceName": {
+                    "$ref": "#/components/schemas/ipodName"
                   }
                 }
               }
@@ -2767,14 +2848,47 @@
             "description": "The default \"from\" email address for outgoing emails.",
             "nullable": true
           },
-          "ereaderDevices": {
+        "ereaderDevices": {
+          "type": "array",
+          "description": "List of configured e-reader devices.",
+          "items": {
+            "$ref": "#/components/schemas/EreaderDeviceObject"
+          }
+        }
+      },
+      "ipodName": {
+        "type": "string",
+        "description": "The name of the iPod device."
+      },
+      "IPodDevice": {
+        "type": "object",
+        "description": "A configured iPod sync device.",
+        "properties": {
+          "name": { "$ref": "#/components/schemas/ipodName" },
+          "ip": { "type": "string", "description": "IP address of the device." },
+          "availabilityOption": {
+            "type": "string",
+            "enum": ["adminOrUp", "userOrUp", "guestOrUp", "specificUsers"]
+          },
+          "users": {
             "type": "array",
-            "description": "List of configured e-reader devices.",
-            "items": {
-              "$ref": "#/components/schemas/EreaderDeviceObject"
-            }
+            "items": { "type": "string" }
           }
         },
+        "required": ["name", "ip", "availabilityOption"]
+      },
+      "IPodSettings": {
+        "type": "object",
+        "description": "Settings for configured iPod devices.",
+        "properties": {
+          "id": { "type": "string", "example": "ipod-settings" },
+          "ipodDevices": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/IPodDevice" }
+          }
+        },
+        "required": ["id", "ipodDevices"]
+      },
         "required": [
           "id",
           "port",
@@ -4040,6 +4154,16 @@
                   }
                 }
               }
+            }
+          }
+        }
+      },
+      "ipodSettings200": {
+        "description": "Successful response - IPod settings",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/IPodSettings"
             }
           }
         }

--- a/docs/root.yaml
+++ b/docs/root.yaml
@@ -29,6 +29,10 @@ paths:
     $ref: './controllers/EmailController.yaml#/paths/~1api~1emails~1ereader-devices'
   /api/emails/send-ebook-to-device:
     $ref: './controllers/EmailController.yaml#/paths/~1api~1emails~1send-ebook-to-device'
+  /api/ipods/settings:
+    $ref: './controllers/IPodController.yaml#/paths/~1api~1ipods~1settings'
+  /api/ipods/send:
+    $ref: './controllers/IPodController.yaml#/paths/~1api~1ipods~1send'
   /api/libraries:
     $ref: './controllers/LibraryController.yaml#/paths/~1api~1libraries'
   /api/libraries/{id}:
@@ -90,3 +94,5 @@ tags:
     description: Notifications endpoints
   - name: Podcasts
     description: Podcast endpoints
+  - name: IPod
+    description: iPod endpoints

--- a/server/Database.js
+++ b/server/Database.js
@@ -28,6 +28,8 @@ class Database {
     this.notificationSettings = null
     /** @type {import('./objects/settings/EmailSettings')} */
     this.emailSettings = null
+    /** @type {import('./objects/settings/IPodSettings')} */
+    this.ipodSettings = null
 
     this.supportsUnaccent = false
     this.supportsUnicodeFoldings = false
@@ -366,6 +368,7 @@ class Database {
     this.emailSettings = settingsData.emailSettings
     this.serverSettings = settingsData.serverSettings
     this.notificationSettings = settingsData.notificationSettings
+    this.ipodSettings = settingsData.ipodSettings
     global.ServerSettings = this.serverSettings.toJSON()
 
     // Version specific migrations

--- a/server/Server.js
+++ b/server/Server.js
@@ -26,6 +26,7 @@ const PublicRouter = require('./routers/PublicRouter')
 
 const LogManager = require('./managers/LogManager')
 const EmailManager = require('./managers/EmailManager')
+const IPodManager = require('./managers/IPodManager')
 const AbMergeManager = require('./managers/AbMergeManager')
 const CacheManager = require('./managers/CacheManager')
 const BackupManager = require('./managers/BackupManager')
@@ -99,6 +100,7 @@ class Server {
 
     // Managers
     this.emailManager = new EmailManager()
+    this.ipodManager = new IPodManager()
     this.backupManager = new BackupManager()
     this.abMergeManager = new AbMergeManager()
     this.playbackSessionManager = new PlaybackSessionManager()

--- a/server/controllers/IPodController.js
+++ b/server/controllers/IPodController.js
@@ -1,0 +1,73 @@
+const { Request, Response, NextFunction } = require('express')
+const Logger = require('../Logger')
+const SocketAuthority = require('../SocketAuthority')
+const Database = require('../Database')
+
+class IPodController {
+  constructor() {}
+
+  /**
+   * GET: /api/ipods/settings
+   * @param {Request & {user: import('../models/User')}} req
+   * @param {Response} res
+   */
+  getSettings(req, res) {
+    res.json({
+      settings: Database.ipodSettings
+    })
+  }
+
+  /**
+   * PATCH: /api/ipods/settings
+   * @param {Request & {user: import('../models/User')}} req
+   * @param {Response} res
+   */
+  async updateSettings(req, res) {
+    const updated = Database.ipodSettings.update(req.body)
+    if (updated) {
+      await Database.updateSetting(Database.ipodSettings)
+      SocketAuthority.adminEmitter('ipod-devices-updated', {
+        ipodDevices: Database.ipodSettings.ipodDevices
+      })
+    }
+    res.json({
+      settings: Database.ipodSettings
+    })
+  }
+
+  /**
+   * POST: /api/ipods/send
+   * @param {Request & {user: import('../models/User')}} req
+   * @param {Response} res
+   */
+  async send(req, res) {
+    const device = Database.ipodSettings.getIPodDevice(req.body.deviceName)
+    if (!device) {
+      return res.status(404).send('iPod device not found')
+    }
+    if (!Database.ipodSettings.checkUserCanAccessDevice(device, req.user)) {
+      return res.sendStatus(403)
+    }
+    const libraryItem = await Database.libraryItemModel.getExpandedById(req.body.libraryItemId)
+    if (!libraryItem) {
+      return res.status(404).send('Library item not found')
+    }
+    if (!req.user.checkCanAccessLibraryItem(libraryItem)) {
+      return res.sendStatus(403)
+    }
+    const file = libraryItem.media.audioFiles?.[0]
+    if (!file) {
+      return res.status(404).send('Audio file not found')
+    }
+    this.ipodManager.sendFileToDevice(file, device, res)
+  }
+
+  adminMiddleware(req, res, next) {
+    if (!req.user.isAdminOrUp) {
+      return res.sendStatus(404)
+    }
+    next()
+  }
+}
+
+module.exports = new IPodController()

--- a/server/managers/IPodManager.js
+++ b/server/managers/IPodManager.js
@@ -1,0 +1,28 @@
+const axios = require('axios')
+const fs = require('fs')
+const FormData = require('form-data')
+const Logger = require('../Logger')
+const Database = require('../Database')
+
+class IPodManager {
+  constructor() {}
+
+  async sendFileToDevice(file, device, res) {
+    Logger.info(`[IPodManager] Sending file "${file.metadata.filename}" to device "${device.name}" at ${device.ip}`)
+
+    const form = new FormData()
+    form.append('file', fs.createReadStream(file.metadata.path))
+
+    try {
+      await axios.post(`http://${device.ip}:8000/upload/audiobook`, form, {
+        headers: form.getHeaders()
+      })
+      res.sendStatus(200)
+    } catch (error) {
+      Logger.error(`[IPodManager] Failed to send file to device`, error)
+      res.status(400).send(error.message || 'Failed to send file to device')
+    }
+  }
+}
+
+module.exports = IPodManager

--- a/server/models/Setting.js
+++ b/server/models/Setting.js
@@ -3,6 +3,7 @@ const { DataTypes, Model } = require('sequelize')
 const oldEmailSettings = require('../objects/settings/EmailSettings')
 const oldServerSettings = require('../objects/settings/ServerSettings')
 const oldNotificationSettings = require('../objects/settings/NotificationSettings')
+const oldIPodSettings = require('../objects/settings/IPodSettings')
 
 class Setting extends Model {
   constructor(values, options) {
@@ -24,12 +25,14 @@ class Setting extends Model {
     const emailSettingsJson = settings.find((se) => se.id === 'email-settings')
     const serverSettingsJson = settings.find((se) => se.id === 'server-settings')
     const notificationSettingsJson = settings.find((se) => se.id === 'notification-settings')
+    const ipodSettingsJson = settings.find((se) => se.id === 'ipod-settings')
 
     return {
       settings,
       emailSettings: new oldEmailSettings(emailSettingsJson),
       serverSettings: new oldServerSettings(serverSettingsJson),
-      notificationSettings: new oldNotificationSettings(notificationSettingsJson)
+      notificationSettings: new oldNotificationSettings(notificationSettingsJson),
+      ipodSettings: new oldIPodSettings(ipodSettingsJson)
     }
   }
 

--- a/server/objects/settings/IPodSettings.js
+++ b/server/objects/settings/IPodSettings.js
@@ -1,0 +1,92 @@
+const Logger = require('../../Logger')
+const { areEquivalent, copyValue } = require('../../utils')
+
+/**
+ * @typedef IPodDevice
+ * @property {string} name
+ * @property {string} ip
+ * @property {string} availabilityOption
+ * @property {string[]} users
+ */
+
+class IPodSettings {
+  constructor(settings = null) {
+    this.id = 'ipod-settings'
+    /** @type {IPodDevice[]} */
+    this.ipodDevices = []
+
+    if (settings) {
+      this.construct(settings)
+    }
+  }
+
+  construct(settings) {
+    this.ipodDevices = settings.ipodDevices?.map((d) => ({ ...d })) || []
+  }
+
+  toJSON() {
+    return {
+      id: this.id,
+      ipodDevices: this.ipodDevices.map((d) => ({ ...d }))
+    }
+  }
+
+  update(payload) {
+    if (!payload) return false
+
+    if (payload.ipodDevices !== undefined && !Array.isArray(payload.ipodDevices)) payload.ipodDevices = undefined
+
+    if (payload.ipodDevices?.length) {
+      payload.ipodDevices = payload.ipodDevices
+        .map((device) => {
+          if (!device.name || !device.ip) {
+            Logger.error(`[IPodSettings] Update device is invalid`, device)
+            return null
+          }
+          if (!device.availabilityOption || !['adminOrUp', 'userOrUp', 'guestOrUp', 'specificUsers'].includes(device.availabilityOption)) {
+            device.availabilityOption = 'adminOrUp'
+          }
+          if (device.availabilityOption === 'specificUsers' && !device.users?.length) {
+            device.availabilityOption = 'adminOrUp'
+          }
+          if (device.availabilityOption !== 'specificUsers' && device.users?.length) {
+            device.users = []
+          }
+          return device
+        })
+        .filter((d) => d)
+    }
+
+    let hasUpdates = false
+    const json = this.toJSON()
+    for (const key in json) {
+      if (key === 'id') continue
+      if (payload[key] !== undefined && !areEquivalent(payload[key], json[key])) {
+        this[key] = copyValue(payload[key])
+        hasUpdates = true
+      }
+    }
+    return hasUpdates
+  }
+
+  checkUserCanAccessDevice(device, user) {
+    const availability = device.availabilityOption || 'adminOrUp'
+    if (availability === 'adminOrUp' && user.isAdminOrUp) return true
+    if (availability === 'userOrUp' && (user.isAdminOrUp || user.isUser)) return true
+    if (availability === 'guestOrUp') return true
+    if (availability === 'specificUsers') {
+      return (device.users || []).includes(user.id)
+    }
+    return false
+  }
+
+  getIPodDevices(user) {
+    return this.ipodDevices.filter((d) => this.checkUserCanAccessDevice(d, user))
+  }
+
+  getIPodDevice(name) {
+    return this.ipodDevices.find((d) => d.name === name)
+  }
+}
+
+module.exports = IPodSettings

--- a/server/routers/ApiRouter.js
+++ b/server/routers/ApiRouter.js
@@ -26,6 +26,7 @@ const SessionController = require('../controllers/SessionController')
 const PodcastController = require('../controllers/PodcastController')
 const NotificationController = require('../controllers/NotificationController')
 const EmailController = require('../controllers/EmailController')
+const IPodController = require('../controllers/IPodController')
 const SearchController = require('../controllers/SearchController')
 const CacheController = require('../controllers/CacheController')
 const ToolsController = require('../controllers/ToolsController')
@@ -53,6 +54,8 @@ class ApiRouter {
     this.cronManager = Server.cronManager
     /** @type {import('../managers/EmailManager')} */
     this.emailManager = Server.emailManager
+    /** @type {import('../managers/IPodManager')} */
+    this.ipodManager = Server.ipodManager
     this.apiCacheManager = Server.apiCacheManager
 
     this.router = express()
@@ -273,6 +276,13 @@ class ApiRouter {
     this.router.post('/emails/test', EmailController.adminMiddleware.bind(this), EmailController.sendTest.bind(this))
     this.router.post('/emails/ereader-devices', EmailController.adminMiddleware.bind(this), EmailController.updateEReaderDevices.bind(this))
     this.router.post('/emails/send-ebook-to-device', EmailController.sendEBookToDevice.bind(this))
+
+    //
+    // iPod Routes (Admin and up for settings)
+    //
+    this.router.get('/ipods/settings', IPodController.adminMiddleware.bind(this), IPodController.getSettings.bind(this))
+    this.router.patch('/ipods/settings', IPodController.adminMiddleware.bind(this), IPodController.updateSettings.bind(this))
+    this.router.post('/ipods/send', IPodController.send.bind(this))
 
     //
     // Search Routes


### PR DESCRIPTION
## Summary
- create `IPodSettings` object with CRUD helpers
- load/persist ipod settings in the database
- implement IPodManager and controller
- register iPod API routes
- document IPod settings and controller in OpenAPI spec

## Testing
- `npm install --no-progress`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d474a071c83238e5d0620a9aa0715