### PR TITLE
Create send to iPod roadmap

### DIFF
--- a/roadmap.md
+++ b/roadmap.md
@@ -1,0 +1,24 @@
+# Audiobookshelf Roadmap
+
+This file tracks our progress on implementing the "Send to iPod" feature.
+Check items off as they are completed.
+
+## Backend implementation
+
+- [ ] `IPodSettings` object for storing device info
+- [ ] Database integration for `ipodSettings`
+- [ ] `IPodManager` uploads files to the Pi
+- [ ] `IPodController` with settings and send endpoints
+- [ ] API routes wired in `ApiRouter`
+- [ ] OpenAPI documentation for new endpoints
+
+## Frontend tasks
+
+- [ ] Expose `ipodDevices` on login and commit them to the store
+- [ ] Vuex state and mutations for `ipodDevices`
+- [ ] Listen for `ipod-devices-updated` socket events
+- [ ] User endpoint `/api/me/ipod-devices` and modal for editing devices
+- [ ] Admin configuration page `config/ipod.vue` and `IPodDeviceModal.vue`
+- [ ] "Send to iPod" actions on item pages and book cards
+- [ ] Add iPod strings to translation files
+- [ ] Update OpenAPI docs and add unit tests


### PR DESCRIPTION
## Summary
- add `roadmap.md` to track Send to iPod tasks

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d8b1a6be08323b3f4e4ce5cc55f46