### PR TITLE
Add admin IPod settings UI and docs

### DIFF
--- a/client/components/modals/ipods/IPodDeviceModal.vue
+++ b/client/components/modals/ipods/IPodDeviceModal.vue
@@ -1,0 +1,197 @@
+<template>
+  <modals-modal ref="modal" v-model="show" name="ipod-device-edit" :width="800" :height="'unset'" :processing="processing">
+    <template #outer>
+      <div class="absolute top-0 left-0 p-5 w-2/3 overflow-hidden">
+        <p class="text-3xl text-white truncate">{{ title }}</p>
+      </div>
+    </template>
+    <form @submit.prevent="submitForm">
+      <div class="w-full text-sm rounded-lg bg-bg shadow-lg border border-black-300">
+        <div class="w-full px-3 py-5 md:p-12">
+          <div class="flex items-center -mx-1 mb-4">
+            <div class="w-full md:w-1/2 px-1">
+              <ui-text-input-with-label ref="ipodNameInput" v-model="newDevice.name" :disabled="processing" :label="$strings.LabelName" />
+            </div>
+            <div class="w-full md:w-1/2 px-1">
+              <ui-text-input-with-label ref="ipodIpInput" v-model="newDevice.ip" :disabled="processing" :label="$strings.LabelIPAddress" />
+            </div>
+          </div>
+          <div class="flex items-center -mx-1 mb-4">
+            <div class="w-full md:w-1/2 px-1">
+              <ui-dropdown v-model="newDevice.availabilityOption" :label="$strings.LabelDeviceIsAvailableTo" :items="userAvailabilityOptions" @input="availabilityOptionChanged" />
+            </div>
+            <div class="w-full md:w-1/2 px-1">
+              <ui-multi-select-dropdown v-if="newDevice.availabilityOption === 'specificUsers'" v-model="newDevice.users" :label="$strings.HeaderUsers" :items="userOptions" />
+            </div>
+          </div>
+
+          <div class="flex items-center pt-4">
+            <div class="grow" />
+            <ui-btn color="bg-success" type="submit">{{ $strings.ButtonSubmit }}</ui-btn>
+          </div>
+        </div>
+      </div>
+    </form>
+  </modals-modal>
+</template>
+
+<script>
+export default {
+  props: {
+    value: Boolean,
+    existingDevices: {
+      type: Array,
+      default: () => []
+    },
+    ipodDevice: {
+      type: Object,
+      default: () => null
+    },
+    users: {
+      type: Array,
+      default: () => []
+    },
+    loadUsers: Function
+  },
+  data() {
+    return {
+      processing: false,
+      newDevice: {
+        name: '',
+        ip: '',
+        availabilityOption: 'adminOrUp',
+        users: []
+      }
+    }
+  },
+  watch: {
+    show: {
+      handler(newVal) {
+        if (newVal) {
+          this.init()
+        }
+      }
+    }
+  },
+  computed: {
+    show: {
+      get() {
+        return this.value
+      },
+      set(val) {
+        this.$emit('input', val)
+      }
+    },
+    title() {
+      return !this.ipodDevice ? 'Create Device' : 'Update Device'
+    },
+    userAvailabilityOptions() {
+      return [
+        { text: this.$strings.LabelAdminUsersOnly, value: 'adminOrUp' },
+        { text: this.$strings.LabelAllUsersExcludingGuests, value: 'userOrUp' },
+        { text: this.$strings.LabelAllUsersIncludingGuests, value: 'guestOrUp' },
+        { text: this.$strings.LabelSelectUsers, value: 'specificUsers' }
+      ]
+    },
+    userOptions() {
+      return this.users.map((u) => ({ text: u.username, value: u.id }))
+    }
+  },
+  methods: {
+    availabilityOptionChanged(option) {
+      if (option === 'specificUsers' && !this.users.length) {
+        this.callLoadUsers()
+      }
+    },
+    async callLoadUsers() {
+      this.processing = true
+      await this.loadUsers()
+      this.processing = false
+    },
+    submitForm() {
+      this.$refs.ipodNameInput.blur()
+      this.$refs.ipodIpInput.blur()
+
+      if (!this.newDevice.name?.trim() || !this.newDevice.ip?.trim()) {
+        this.$toast.error(this.$strings.ToastNameIpRequired)
+        return
+      }
+
+      if (this.newDevice.availabilityOption === 'specificUsers' && !this.newDevice.users.length) {
+        this.$toast.error(this.$strings.ToastSelectAtLeastOneUser)
+        return
+      }
+      if (this.newDevice.availabilityOption !== 'specificUsers') {
+        this.newDevice.users = []
+      }
+
+      this.newDevice.name = this.newDevice.name.trim()
+      this.newDevice.ip = this.newDevice.ip.trim()
+
+      if (!this.ipodDevice) {
+        if (this.existingDevices.some((d) => d.name === this.newDevice.name)) {
+          this.$toast.error(this.$strings.ToastDeviceNameAlreadyExists)
+          return
+        }
+        this.submitCreate()
+      } else {
+        if (this.ipodDevice.name !== this.newDevice.name && this.existingDevices.some((d) => d.name === this.newDevice.name)) {
+          this.$toast.error(this.$strings.ToastDeviceNameAlreadyExists)
+          return
+        }
+        this.submitUpdate()
+      }
+    },
+    submitUpdate() {
+      this.processing = true
+      const existingWithout = this.existingDevices.filter((d) => d.name !== this.ipodDevice.name)
+      const payload = {
+        ipodDevices: [...existingWithout, { ...this.newDevice }]
+      }
+      this.$axios
+        .$patch('/api/ipods/settings', payload)
+        .then((data) => {
+          this.$emit('update', data.settings.ipodDevices)
+          this.show = false
+        })
+        .catch(() => {
+          this.$toast.error(this.$strings.ToastFailedToUpdate)
+        })
+        .finally(() => {
+          this.processing = false
+        })
+    },
+    submitCreate() {
+      this.processing = true
+      const payload = {
+        ipodDevices: [...this.existingDevices, { ...this.newDevice }]
+      }
+      this.$axios
+        .$patch('/api/ipods/settings', payload)
+        .then((data) => {
+          this.$emit('update', data.settings.ipodDevices || [])
+          this.show = false
+        })
+        .catch(() => {
+          this.$toast.error(this.$strings.ToastDeviceAddFailed)
+        })
+        .finally(() => {
+          this.processing = false
+        })
+    },
+    init() {
+      if (this.ipodDevice) {
+        this.newDevice.name = this.ipodDevice.name
+        this.newDevice.ip = this.ipodDevice.ip
+        this.newDevice.availabilityOption = this.ipodDevice.availabilityOption || 'adminOrUp'
+        this.newDevice.users = this.ipodDevice.users || []
+      } else {
+        this.newDevice.name = ''
+        this.newDevice.ip = ''
+        this.newDevice.availabilityOption = 'adminOrUp'
+        this.newDevice.users = []
+      }
+    }
+  }
+}
+</script>

--- a/client/pages/config/ipod.vue
+++ b/client/pages/config/ipod.vue
@@ -1,0 +1,152 @@
+<template>
+  <div>
+    <app-settings-content :header-text="$strings.HeaderIPodDevices" :description="$strings.MessageIPodDevices">
+      <template #header-items>
+        <div class="grow" />
+        <ui-btn color="bg-primary" small @click="addNewDeviceClick">{{ $strings.ButtonAddDevice }}</ui-btn>
+      </template>
+
+      <table v-if="existingIPodDevices.length" class="tracksTable mt-4">
+        <tr>
+          <th class="text-left">{{ $strings.LabelName }}</th>
+          <th class="text-left">{{ $strings.LabelIPAddress }}</th>
+          <th class="text-left">{{ $strings.LabelAccessibleBy }}</th>
+          <th class="w-40"></th>
+        </tr>
+        <tr v-for="device in existingIPodDevices" :key="device.name">
+          <td>
+            <p class="text-sm md:text-base text-gray-100">{{ device.name }}</p>
+          </td>
+          <td class="text-left">
+            <p class="text-sm md:text-base text-gray-100">{{ device.ip }}</p>
+          </td>
+          <td class="text-left">
+            <p class="text-sm md:text-base text-gray-100">{{ getAccessibleBy(device) }}</p>
+          </td>
+          <td class="w-40">
+            <div class="flex justify-end items-center h-10">
+              <ui-icon-btn icon="edit" borderless :size="8" icon-font-size="1.1rem" :disabled="deletingDeviceName === device.name" class="mx-1" @click="editDeviceClick(device)" />
+              <ui-icon-btn icon="delete" borderless :size="8" icon-font-size="1.1rem" :disabled="deletingDeviceName === device.name" @click="deleteDeviceClick(device)" />
+            </div>
+          </td>
+        </tr>
+      </table>
+      <div v-else-if="!loading" class="text-center py-4">
+        <p class="text-lg text-gray-100">{{ $strings.MessageNoDevices }}</p>
+      </div>
+    </app-settings-content>
+
+    <modals-ipods-i-pod-device-modal
+      v-model="showIPodDeviceModal"
+      :users="users"
+      :existing-devices="existingIPodDevices"
+      :ipod-device="selectedIPodDevice"
+      @update="ipodDevicesUpdated"
+      :loadUsers="loadUsers"
+    />
+  </div>
+</template>
+
+<script>
+export default {
+  asyncData({ store, redirect }) {
+    if (!store.getters['user/getIsAdminOrUp']) {
+      redirect('/')
+    }
+  },
+  data() {
+    return {
+      users: [],
+      loading: false,
+      deletingDeviceName: null,
+      settings: null,
+      selectedIPodDevice: null,
+      showIPodDeviceModal: false
+    }
+  },
+  computed: {
+    existingIPodDevices() {
+      return this.settings?.ipodDevices || []
+    }
+  },
+  methods: {
+    async loadUsers() {
+      if (this.users.length) return
+      this.users = await this.$axios
+        .$get('/api/users')
+        .then((res) => res.users.sort((a, b) => a.createdAt - b.createdAt))
+        .catch(() => {
+          this.$toast.error(this.$strings.ToastFailedToLoadData)
+          return []
+        })
+    },
+    getAccessibleBy(device) {
+      const user = device.availabilityOption
+      if (user === 'userOrUp') return 'Users (excluding Guests)'
+      if (user === 'guestOrUp') return 'Users (including Guests)'
+      if (user === 'specificUsers') {
+        return device.users.map((id) => this.users.find((u) => u.id === id)?.username).join(', ')
+      }
+      return 'Admins Only'
+    },
+    editDeviceClick(device) {
+      this.selectedIPodDevice = device
+      this.showIPodDeviceModal = true
+    },
+    deleteDeviceClick(device) {
+      const payload = {
+        message: this.$getString('MessageConfirmDeleteDevice', [device.name]),
+        callback: (confirmed) => {
+          if (confirmed) this.deleteDevice(device)
+        },
+        type: 'yesNo'
+      }
+      this.$store.commit('globals/setConfirmPrompt', payload)
+    },
+    deleteDevice(device) {
+      const payload = {
+        ipodDevices: this.existingIPodDevices.filter((d) => d.name !== device.name)
+      }
+      this.deletingDeviceName = device.name
+      this.$axios
+        .$patch('/api/ipods/settings', payload)
+        .then((data) => {
+          this.ipodDevicesUpdated(data.settings.ipodDevices)
+        })
+        .catch(() => {
+          this.$toast.error(this.$strings.ToastRemoveFailed)
+        })
+        .finally(() => {
+          this.deletingDeviceName = null
+        })
+    },
+    ipodDevicesUpdated(ipodDevices) {
+      this.settings.ipodDevices = ipodDevices
+    },
+    addNewDeviceClick() {
+      this.selectedIPodDevice = null
+      this.showIPodDeviceModal = true
+    },
+    async init() {
+      this.loading = true
+      this.$axios
+        .$get('/api/ipods/settings')
+        .then(async (data) => {
+          if (data.settings.ipodDevices.some((d) => d.availabilityOption === 'specificUsers')) {
+            await this.loadUsers()
+          }
+          this.settings = data.settings
+        })
+        .catch(() => {
+          this.$toast.error(this.$strings.ToastFailedToLoadData)
+        })
+        .finally(() => {
+          this.loading = false
+        })
+    }
+  },
+  mounted() {
+    this.init()
+  }
+}
+</script>

--- a/docs/controllers/MeController.yaml
+++ b/docs/controllers/MeController.yaml
@@ -1,0 +1,36 @@
+components:
+  responses:
+    ipodDevices200:
+      description: Successful response - IPod devices
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              ipodDevices:
+                type: array
+                items:
+                  $ref: '../objects/settings/IPodSettings.yaml#/components/schemas/IPodDevice'
+paths:
+  /api/me/ipod-devices:
+    post:
+      summary: Update user iPod devices
+      operationId: updateUserIPodDevices
+      tags:
+        - IPod
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                ipodDevices:
+                  type: array
+                  items:
+                    $ref: '../objects/settings/IPodSettings.yaml#/components/schemas/IPodDevice'
+      responses:
+        200:
+          $ref: '#/components/responses/ipodDevices200'
+        400:
+          description: Invalid payload

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -632,6 +632,37 @@
         }
       }
     },
+    "/api/me/ipod-devices": {
+      "post": {
+        "summary": "Update user iPod devices",
+        "operationId": "updateUserIPodDevices",
+        "tags": [
+          "IPod"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "ipodDevices": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/IPodDevice"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": { "$ref": "#/components/responses/ipodDevices200" },
+          "400": { "description": "Invalid payload" }
+        }
+      }
+    },
     "/api/libraries": {
       "get": {
         "operationId": "getLibraries",
@@ -4164,6 +4195,24 @@
           "application/json": {
             "schema": {
               "$ref": "#/components/schemas/IPodSettings"
+            }
+          }
+        }
+      },
+      "ipodDevices200": {
+        "description": "Successful response - IPod devices",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "ipodDevices": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/IPodDevice"
+                  }
+                }
+              }
             }
           }
         }

--- a/docs/root.yaml
+++ b/docs/root.yaml
@@ -33,6 +33,8 @@ paths:
     $ref: './controllers/IPodController.yaml#/paths/~1api~1ipods~1settings'
   /api/ipods/send:
     $ref: './controllers/IPodController.yaml#/paths/~1api~1ipods~1send'
+  /api/me/ipod-devices:
+    $ref: './controllers/MeController.yaml#/paths/~1api~1me~1ipod-devices'
   /api/libraries:
     $ref: './controllers/LibraryController.yaml#/paths/~1api~1libraries'
   /api/libraries/{id}:

--- a/test/server/controllers/MeControllerIPodDevices.test.js
+++ b/test/server/controllers/MeControllerIPodDevices.test.js
@@ -1,0 +1,66 @@
+const { expect } = require('chai')
+const sinon = require('sinon')
+
+const MeController = require('../../../server/controllers/MeController')
+const Database = require('../../../server/Database')
+const IPodSettings = require('../../../server/objects/settings/IPodSettings')
+const SocketAuthority = require('../../../server/SocketAuthority')
+
+describe('MeController.updateUserIPodDevices', () => {
+  let ipodSettings
+  beforeEach(() => {
+    ipodSettings = new IPodSettings({
+      ipodDevices: [
+        { name: 'AdminPod', ip: '2.2.2.2', availabilityOption: 'adminOrUp', users: [] }
+      ]
+    })
+    Database.ipodSettings = ipodSettings
+    sinon.stub(Database, 'updateSetting').resolves(true)
+    sinon.stub(SocketAuthority, 'clientEmitter')
+  })
+
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  it('should update user devices and return updated list', async () => {
+    const req = {
+      body: {
+        ipodDevices: [
+          { name: 'UserPod', ip: '1.1.1.1', availabilityOption: 'specificUsers', users: ['1'] }
+        ]
+      },
+      user: { id: '1' }
+    }
+    const res = {
+      status: sinon.stub().returnsThis(),
+      send: sinon.spy(),
+      json: sinon.spy()
+    }
+    await MeController.updateUserIPodDevices(req, res)
+    expect(res.status.called).to.be.false
+    expect(res.json.calledOnce).to.be.true
+    const returned = res.json.firstCall.args[0].ipodDevices
+    expect(returned.some((d) => d.name === 'UserPod')).to.be.true
+    expect(Database.ipodSettings.ipodDevices.length).to.equal(2)
+  })
+
+  it('should reject payload with duplicate names', async () => {
+    const req = {
+      body: {
+        ipodDevices: [
+          { name: 'AdminPod', ip: '1.1.1.1', availabilityOption: 'specificUsers', users: ['1'] }
+        ]
+      },
+      user: { id: '1' }
+    }
+    const res = {
+      status: sinon.stub().returnsThis(),
+      send: sinon.spy(),
+      json: sinon.spy()
+    }
+    await MeController.updateUserIPodDevices(req, res)
+    expect(res.status.calledWith(400)).to.be.true
+    expect(res.send.called).to.be.true
+  })
+})


### PR DESCRIPTION
## Summary
- implement admin config page for IPod devices
- add IPodDeviceModal component
- document `/api/me/ipod-devices` in OpenAPI spec
- add unit tests for updating user IPod devices

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d9f43e54c8323ba447337ba73bd9b