### PR TITLE
Add iPod dock API key support

### DIFF
--- a/docs/ipod_integration_plan.md
+++ b/docs/ipod_integration_plan.md
@@ -30,6 +30,10 @@ This document outlines the plan for adding "Send to iPod" support in Audiobooksh
 ## Raspberry Pi Plugin API
 
 The Raspberry Pi sync dock exposes a simple REST interface implemented with FastAPI.
+All requests must include a secret API key using the `Authorization` header. The
+key value is provided by the iPod dock and should be sent as `Bearer <API_KEY>`.
+Set the `IPOD_DOCK_API_KEY` environment variable in Audiobookshelf so the server
+can authenticate requests.
 
 ### Starting the server
 
@@ -44,17 +48,19 @@ By default the server listens on port `8000` on all interfaces.
 - **GET `/status`** – Health check. Returns `{"status": "ok"}`.
 - **POST `/upload`** – Upload an audio file using `multipart/form-data` field `file`.
 
-  Example:
-  ```bash
-  curl -F "file=@song.mp3" http://<pi>:8000/upload
-  ```
+Example:
+```bash
+curl -H "Authorization: Bearer <API_KEY>" \
+     -F "file=@song.mp3" http://<pi>:8000/upload
+```
   Response: `{"queued": "song.mp3"}`
 
 - **POST `/upload/{category}`** – Upload to `music` or `audiobook` category.
 
-  ```bash
-  curl -F "file=@book.m4b" http://<pi>:8000/upload/audiobook
-  ```
+```bash
+curl -H "Authorization: Bearer <API_KEY>" \
+     -F "file=@book.m4b" http://<pi>:8000/upload/audiobook
+```
   Response: `{"queued": "book.m4b", "category": "audiobook"}`
 
 - **GET `/tracks`** – Retrieve a list of tracks on the iPod.
@@ -68,6 +74,6 @@ By default the server listens on port `8000` on all interfaces.
 
 ### Notes
 
-- Authentication is not yet implemented, so expose the API only on trusted networks.
+- Include the API key in the `Authorization` header for every request.
 - Uploaded files must be in a format supported by the iPod (MP3 or AAC). Conversion is outside the scope of the API.
 

--- a/server/managers/IPodManager.js
+++ b/server/managers/IPodManager.js
@@ -14,8 +14,12 @@ class IPodManager {
     form.append('file', fs.createReadStream(file.metadata.path))
 
     try {
+      const headers = form.getHeaders()
+      if (process.env.IPOD_DOCK_API_KEY) {
+        headers['Authorization'] = `Bearer ${process.env.IPOD_DOCK_API_KEY}`
+      }
       await axios.post(`http://${device.ip}:8000/upload/audiobook`, form, {
-        headers: form.getHeaders()
+        headers
       })
       res.sendStatus(200)
     } catch (error) {


### PR DESCRIPTION
## Summary
- document new API key requirement for the Raspberry Pi iPod dock
- send Authorization header from IPodManager when the `IPOD_DOCK_API_KEY` env var is set

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684dd3bb53348323b687b1038a9c03b2